### PR TITLE
Remove redundant host permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "typescript": "5.3.3"
   },
   "manifest": {
-    "permissions": ["storage", "activeTab", "tabs", "contextMenus"],
-    "host_permissions": [
-      "https://*/*"
-    ]
+    "permissions": ["storage", "activeTab", "tabs", "contextMenus"]
   }
 }


### PR DESCRIPTION
## Summary
- drop host_permissions from the manifest

## Testing
- `npm run build`
- `npm run package`


------
https://chatgpt.com/codex/tasks/task_e_688cf83c69e8832e8289ac686990f0f5